### PR TITLE
Add basic health endpoint test

### DIFF
--- a/app.js
+++ b/app.js
@@ -88,15 +88,18 @@ app.use(errorHandler);
 
 // 서버 시작
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => {
-  console.log('🚀=================================🚀');
-  console.log(`   SeoulTech Chat API Server       `);
-  console.log('🚀=================================🚀');
-  console.log(`🌐 API Server: http://localhost:${PORT}`);
-  console.log(`📚 API Docs: http://localhost:${PORT}/api-docs`);
-  console.log(`💊 Health Check: http://localhost:${PORT}/health`);
-  console.log(`📱 React App: http://localhost:3001`);
-  console.log('🚀=================================🚀');
-});
+
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log('🚀=================================🚀');
+    console.log(`   SeoulTech Chat API Server       `);
+    console.log('🚀=================================🚀');
+    console.log(`🌐 API Server: http://localhost:${PORT}`);
+    console.log(`📚 API Docs: http://localhost:${PORT}/api-docs`);
+    console.log(`💊 Health Check: http://localhost:${PORT}/health`);
+    console.log(`📱 React App: http://localhost:3001`);
+    console.log('🚀=================================🚀');
+  });
+}
 
 module.exports = app;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "SeoulTech Chat API Server",
   "main": "app.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node tests/basic.test.js",
     "start": "node app.js",
     "dev": "nodemon app.js"
   },

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -1,0 +1,34 @@
+const assert = require('assert');
+const app = require('../app');
+
+async function run() {
+  const server = app.listen(0);
+  const port = server.address().port;
+
+  try {
+    // Test /health endpoint
+    let res = await fetch(`http://localhost:${port}/health`);
+    assert.strictEqual(res.status, 200, '/health should return 200');
+    let data = await res.json();
+    assert.strictEqual(data.status, 'OK');
+
+    // Test root endpoint
+    res = await fetch(`http://localhost:${port}/`);
+    assert.strictEqual(res.status, 200, 'root should return 200');
+    data = await res.json();
+    assert.strictEqual(data.status, 'running');
+
+    // Test 404
+    res = await fetch(`http://localhost:${port}/nope`);
+    assert.strictEqual(res.status, 404, 'unknown route should return 404');
+
+    console.log('All tests passed');
+  } finally {
+    server.close();
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- ensure `app.js` only starts the server when run directly
- add simple test script using Node `assert`
- make `npm test` execute the test script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684bdc2f7580832889329d2899160476